### PR TITLE
Add more math aliases

### DIFF
--- a/src/Currency.js
+++ b/src/Currency.js
@@ -68,9 +68,9 @@ export class CurrencyRatio extends Currency {
 }
 
 const mathFunctions = [
-  ['plus'],
-  ['minus'],
-  ['times', 'multipliedBy'],
+  ['plus', 'add'],
+  ['minus', 'sub'],
+  ['times', 'multipliedBy', 'mul'],
   ['div', 'dividedBy'],
   ['shiftedBy']
 ];


### PR DESCRIPTION
adds `add`, `sub`, and `mul`

These are the terms used in our smart contracts and I always find myself reaching for them. What do you think?